### PR TITLE
Fixed Backspace issues

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -8,7 +8,7 @@ import numpy as np
 import pyqtgraph as pg
 from PyQt4.QtCore import *
 from PyQt4.QtGui import *
-prev= ""
+
 
 class Graph(QtGui.QMainWindow): #Auxiliary class to display pop-up for inputting range
     def __init__(self,parent = None):
@@ -107,7 +107,7 @@ class calculator_class(calculator.Ui_Dialog,QtGui.QMainWindow):
 		self.b9.clicked.connect(lambda:self.display_screen('9'))
 		self.b9.clicked.connect(lambda:self.storage('9',1))
 		self.bco.clicked.connect(lambda:self.display_screen('j'))
-		self.bco.clicked.connect(lambda:self.storage('j',1))
+		self.bco.clicked.connect(lambda:self.storage('1j',1))
 		self.decimal.clicked.connect(lambda:self.display_screen('.'))
 		self.decimal.clicked.connect(lambda:self.storage('.',1))
 		self.add.clicked.connect(lambda:self.display_screen(' + '))
@@ -167,6 +167,7 @@ class calculator_class(calculator.Ui_Dialog,QtGui.QMainWindow):
 	stack = []
 	stack_disp = []
 	temp = []
+	flag = 0
 	def graphing(self):
 		self.flag = 1
 		print("Welcome to graphs")
@@ -200,6 +201,7 @@ class calculator_class(calculator.Ui_Dialog,QtGui.QMainWindow):
 		if k is 1 :
 			self.store=self.store + value
 		elif k is 3:
+			self.flag = 0
 			self.stack=[]
 			self.stack_disp=[]
 			self.store=""
@@ -219,6 +221,7 @@ class calculator_class(calculator.Ui_Dialog,QtGui.QMainWindow):
 			self.stack_disp.pop()
 		except IndexError:
 			self.display_screen1("")
+			self.flag = 0
 		else:
 			if(self.flag == 1):
 				self.display.setText("Enter the equation f(x) : ")
@@ -243,6 +246,18 @@ class calculator_class(calculator.Ui_Dialog,QtGui.QMainWindow):
 		screen_value=str(screen_value)
 		print(''.join(self.stack))
 		try:
+			i = 0
+			while i < len(screen_value):							
+				i = screen_value.find("1j",i)
+				if i == -1:
+					print("Nothing complex")
+					break
+				elif(i == 0 or screen_value[i-1] < '0' or screen_value[i-1] > '9'):
+					print("Okay only 1j")
+				else:
+					if(i):
+						screen_value = screen_value[:i] + screen_value[i+1:]
+				i += 2
 			final_value=eval(screen_value)
 		except ZeroDivisionError:
 			print("Math Error : Division by Zero")


### PR DESCRIPTION
Also fixed the error displayed when only j was entered as input. Python didn't understand j as complex unless it is prefixed with some constant.